### PR TITLE
docs: removed references to `typeChecked`

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,8 +120,8 @@ import { files } from 'eslint-config-spartan/utils';
 export default buildConfig(
   typeEnabled({
     parserOptions: {
-      tsconfigRootDir: __dirname,
-      project: './tsconfig.json',
+      tsconfigRootDir: import.meta.dirname,
+      projectService: true,
     },
   }),
   jsDoc,

--- a/README.md
+++ b/README.md
@@ -114,11 +114,11 @@ receive other configs or mixins as inputs, which are included in the final confi
 ```js
 // eslint.config.js
 import { buildConfig } from 'eslint-config-spartan';
-import { jsDoc, prettier, typeChecked } from 'eslint-config-spartan/mixins';
+import { jsDoc, prettier, typeEnabled } from 'eslint-config-spartan/mixins';
 import { files } from 'eslint-config-spartan/utils';
 
 export default buildConfig(
-  typeChecked({
+  typeEnabled({
     parserOptions: {
       tsconfigRootDir: __dirname,
       project: './tsconfig.json',


### PR DESCRIPTION
## Purpose
We noticed that there was a reference to `typeChecked` in the example but that it was likely supposed to refer to the `typeEnabled` mixin. Just swapped out the naming in the example to help reduce confusion for the next person.