### PR TITLE
Fix/storybook

### DIFF
--- a/src/mixins/storybook.js
+++ b/src/mixins/storybook.js
@@ -36,7 +36,7 @@ export function storybook(options = {}) {
       case 'storybook:recommended:main-rules':
         return {
           ...config,
-          files: options.files ?? [files.storybookMain],
+          files: options.mainFiles ?? [files.storybookMain],
           name: `${CONFIG_NAME_PREFIX}/${storybook.name}/${i}-${config.name}`,
         };
       default:

--- a/src/mixins/storybook.js
+++ b/src/mixins/storybook.js
@@ -1,10 +1,13 @@
-import { CONFIG_NAME_PREFIX } from '../constants.js';
+import { CONFIG_NAME_PREFIX, prefixes } from '../constants.js';
 import { files, warnToError } from '../utils/index.js';
 import storybookExport from 'eslint-plugin-storybook';
-/** @import { Linter } from 'eslint' */
+/** @import { ESLint, Linter } from 'eslint' */
 
 // @ts-expect-error: The types use .default, but the actual object does not
 const storybookPlugin = /** @type {typeof storybookExport.default} */ (storybookExport);
+
+/** @type {Record<string, ESLint.Plugin>} */
+const plugins = /** @type {any} */ ({ [prefixes.storybook]: storybookPlugin });
 
 /**
  * The `storybook` mixin creates an ESLint config for
@@ -25,6 +28,7 @@ export function storybook(options = {}) {
       case 'storybook:recommended:stories-rules':
         return {
           ...config,
+          plugins,
           files: options.files ?? [files.stories],
           name: `${CONFIG_NAME_PREFIX}/${storybook.name}/${i}-${config.name}`,
           rules: {
@@ -36,6 +40,7 @@ export function storybook(options = {}) {
       case 'storybook:recommended:main-rules':
         return {
           ...config,
+          plugins,
           files: options.mainFiles ?? [files.storybookMain],
           name: `${CONFIG_NAME_PREFIX}/${storybook.name}/${i}-${config.name}`,
         };
@@ -43,6 +48,7 @@ export function storybook(options = {}) {
         // Known other cases: 'storybook:recommended:setup'
         return {
           ...config,
+          plugins,
           files: options.files ?? [files.stories],
           name: `${CONFIG_NAME_PREFIX}/${storybook.name}/${i}-${config.name}`,
         };

--- a/src/mixins/storybook.test.ts
+++ b/src/mixins/storybook.test.ts
@@ -37,12 +37,6 @@ describe(storybook.name, () => {
     expect(testTable).toHaveLength(configs.length);
   });
 
-  it('should add the expected plugins to the configs', () => {
-    const actual = new Set(configs.flatMap((x) => Object.keys(x.plugins ?? {})));
-    const expected = new Set([prefixes.storybook]);
-    expect(actual).toStrictEqual(expected);
-  });
-
   describe.each(testTable)('$id', (item) => {
     const { id, expectedFiles, filesOverride, mainFilesOverride, expectedFilesOverride } = item;
     const index = testTable.indexOf(item);
@@ -51,6 +45,12 @@ describe(storybook.name, () => {
     it('should create a valid eslint config', () => {
       const actual = () => configSchema.parse(config);
       expect(actual).not.toThrow();
+    });
+
+    it('should add the expected plugins to the config', () => {
+      const actual = new Set(Object.keys(config.plugins ?? {}));
+      const expected = new Set([prefixes.storybook]);
+      expect(actual).toStrictEqual(expected);
     });
 
     it('should configure the expected rules', () => {


### PR DESCRIPTION
* fixes: #43 
  * For some reason, the storybook plugin requires itself to be added into every config object where storybook rules are used, so this adds it in all the exported storybook configs. 
* This also fixes a bug where the mainFiles options were not being applied to the relevant config
